### PR TITLE
feat(media): add package skeleton and test stubs

### DIFF
--- a/src/chatx/media/__init__.py
+++ b/src/chatx/media/__init__.py
@@ -1,0 +1,7 @@
+"""Media utilities placeholder."""
+
+from .exif import read_exif
+from .hash import sha256_stream
+from .sniff import sniff_mime
+
+__all__ = ["sniff_mime", "read_exif", "sha256_stream"]

--- a/src/chatx/media/exif.py
+++ b/src/chatx/media/exif.py
@@ -1,0 +1,9 @@
+"""EXIF parsing utilities."""
+
+
+def read_exif(path: str) -> dict:  # pragma: no cover - NotImplemented
+    """Return EXIF metadata for *path*.
+
+    Currently unimplemented; will parse EXIF tags in future.
+    """
+    raise NotImplementedError

--- a/src/chatx/media/hash.py
+++ b/src/chatx/media/hash.py
@@ -1,0 +1,9 @@
+"""Hashing utilities."""
+
+
+def sha256_stream(path: str) -> str:  # pragma: no cover - NotImplemented
+    """Return the SHA-256 hex digest for *path*.
+
+    Currently unimplemented; will stream-read file in future.
+    """
+    raise NotImplementedError

--- a/src/chatx/media/sniff.py
+++ b/src/chatx/media/sniff.py
@@ -1,0 +1,9 @@
+"""MIME sniffing utilities."""
+
+
+def sniff_mime(path: str) -> str:  # pragma: no cover - NotImplemented
+    """Return the detected MIME type for *path*.
+
+    Currently unimplemented; will sniff magic bytes in future.
+    """
+    raise NotImplementedError

--- a/tests/media/test_exif.py
+++ b/tests/media/test_exif.py
@@ -1,0 +1,10 @@
+"""Stub tests for media.exif."""
+
+import pytest
+
+from chatx.media.exif import read_exif
+
+
+def test_read_exif_raises_not_implemented():
+    with pytest.raises(NotImplementedError):
+        read_exif("/dev/null")

--- a/tests/media/test_exif.py
+++ b/tests/media/test_exif.py
@@ -5,6 +5,6 @@ import pytest
 from chatx.media.exif import read_exif
 
 
-def test_read_exif_raises_not_implemented():
-    with pytest.raises(NotImplementedError):
-        read_exif("/dev/null")
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="stub")
+def test_read_exif_unimplemented():
+    read_exif("/dev/null")

--- a/tests/media/test_hash.py
+++ b/tests/media/test_hash.py
@@ -5,6 +5,6 @@ import pytest
 from chatx.media.hash import sha256_stream
 
 
-def test_sha256_stream_raises_not_implemented():
-    with pytest.raises(NotImplementedError):
-        sha256_stream("/dev/null")
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="stub")
+def test_sha256_stream_unimplemented():
+    sha256_stream("/dev/null")

--- a/tests/media/test_hash.py
+++ b/tests/media/test_hash.py
@@ -1,0 +1,10 @@
+"""Stub tests for media.hash."""
+
+import pytest
+
+from chatx.media.hash import sha256_stream
+
+
+def test_sha256_stream_raises_not_implemented():
+    with pytest.raises(NotImplementedError):
+        sha256_stream("/dev/null")

--- a/tests/media/test_sniff.py
+++ b/tests/media/test_sniff.py
@@ -1,0 +1,10 @@
+"""Stub tests for media.sniff."""
+
+import pytest
+
+from chatx.media.sniff import sniff_mime
+
+
+def test_sniff_raises_not_implemented():
+    with pytest.raises(NotImplementedError):
+        sniff_mime("/dev/null")

--- a/tests/media/test_sniff.py
+++ b/tests/media/test_sniff.py
@@ -5,6 +5,6 @@ import pytest
 from chatx.media.sniff import sniff_mime
 
 
-def test_sniff_raises_not_implemented():
-    with pytest.raises(NotImplementedError):
-        sniff_mime("/dev/null")
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="stub")
+def test_sniff_unimplemented():
+    sniff_mime("/dev/null")


### PR DESCRIPTION
## Summary
- scaffold `chatx.media` package with `sniff_mime`, `read_exif`, and `sha256_stream` placeholders
- add stub tests asserting `NotImplementedError` for the media helpers

## Testing
- `ruff check src/chatx/media tests/media`
- `mypy src` *(fails: Missing named argument "enrichment" for "EnrichmentResponse", etc.)*
- `pytest tests/media -q -o addopts="--cov=src/chatx/media --cov-report=term-missing --cov-fail-under=60"`


------
https://chatgpt.com/codex/tasks/task_e_68b6ec7602d88326ac3c44b131c11a55