### PR TITLE
feat(media): add image utilities and observability

### DIFF
--- a/config/arch-gates.yml
+++ b/config/arch-gates.yml
@@ -74,6 +74,10 @@ PY
       - name: Metrics summary
         run: |
           chatx metrics summarize --inputs ./out/metrics/*.jsonl --out ./out/reports/run_report.json || true
+      - name: Run report schema
+        run: |
+          test -f ./out/reports/run_report.json
+          jsonschema -i ./out/reports/run_report.json ./schemas/run_report.schema.json
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
     "pre-commit>=3.5.0",
     "mkdocs-material>=9.0.0",
     "types-jsonschema>=4.0.0",
+    "pillow>=10.0.0",
 ]
 
 [project.urls]

--- a/schemas/metrics.schema.json
+++ b/schemas/metrics.schema.json
@@ -11,18 +11,19 @@
     "started_at": { "type": "string", "format": "date-time" },
     "finished_at": { "type": "string", "format": "date-time" },
     "duration_s": { "type": "number", "minimum": 0 },
-    "counters": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "messages_total": { "type": "integer", "minimum": 0 },
-        "chunks_total": { "type": "integer", "minimum": 0 },
-        "attachments_total": { "type": "integer", "minimum": 0 },
-        "redaction_tokens": { "type": "integer", "minimum": 0 },
-        "coverage": { "type": "number", "minimum": 0, "maximum": 1 },
-        "embeddings_written": { "type": "integer", "minimum": 0 },
-        "index_upserts": { "type": "integer", "minimum": 0 },
-        "enrichment_items": { "type": "integer", "minimum": 0 },
+        "counters": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "messages_total": { "type": "integer", "minimum": 0 },
+            "chunks_total": { "type": "integer", "minimum": 0 },
+            "attachments_total": { "type": "integer", "minimum": 0 },
+            "images_total": { "type": "integer", "minimum": 0 },
+            "redaction_tokens": { "type": "integer", "minimum": 0 },
+            "coverage": { "type": "number", "minimum": 0, "maximum": 1 },
+            "embeddings_written": { "type": "integer", "minimum": 0 },
+            "index_upserts": { "type": "integer", "minimum": 0 },
+            "enrichment_items": { "type": "integer", "minimum": 0 },
         "throughput_msgs_min": { "type": "number", "minimum": 0 }
       }
     },

--- a/schemas/run_report.schema.json
+++ b/schemas/run_report.schema.json
@@ -13,16 +13,17 @@
       "type": "array",
       "items": { "$ref": "metrics.schema.json" }
     },
-    "summary": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "messages_total": { "type": "integer", "minimum": 0 },
-        "chunks_total": { "type": "integer", "minimum": 0 },
-        "coverage_min": { "type": "number", "minimum": 0, "maximum": 1 },
-        "coverage_max": { "type": "number", "minimum": 0, "maximum": 1 },
-        "duration_s": { "type": "number", "minimum": 0 }
-      }
-    }
+        "summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "messages_total": { "type": "integer", "minimum": 0 },
+            "chunks_total": { "type": "integer", "minimum": 0 },
+            "images_total": { "type": "integer", "minimum": 0 },
+            "coverage_min": { "type": "number", "minimum": 0, "maximum": 1 },
+            "coverage_max": { "type": "number", "minimum": 0, "maximum": 1 },
+            "duration_s": { "type": "number", "minimum": 0 }
+          }
+        }
   }
 }

--- a/src/chatx/cli/main.py
+++ b/src/chatx/cli/main.py
@@ -749,6 +749,9 @@ def imessage_pull(
             from chatx.utils.run_report import write_extract_run_report
             # Compute simple counters
             attachments_total = sum(len(m.attachments) for m in messages)
+            images_total = sum(
+                1 for m in messages for a in m.attachments if a.type == "image"
+            )
             elapsed = max((finished_at - started_at).total_seconds(), 0.0)
             rate = (len(messages) / elapsed * 60.0) if elapsed > 0 else 0.0
 
@@ -779,6 +782,7 @@ def imessage_pull(
                 finished_at=finished_at,
                 messages_total=len(messages),
                 attachments_total=attachments_total,
+                images_total=images_total,
                 throughput_msgs_min=rate,
                 artifacts=artifacts,
                 warnings=warn_msgs,
@@ -792,6 +796,7 @@ def imessage_pull(
                 counters = {
                     "messages_total": len(messages),
                     "attachments_total": attachments_total,
+                    "images_total": images_total,
                     "throughput_msgs_min": rate,
                 }
                 metrics_path = append_metrics_event(

--- a/src/chatx/media/exif.py
+++ b/src/chatx/media/exif.py
@@ -1,9 +1,26 @@
 """EXIF parsing utilities."""
 
+from __future__ import annotations
 
-def read_exif(path: str) -> dict:  # pragma: no cover - NotImplemented
+from typing import Any, Dict
+
+
+def read_exif(path: str) -> Dict[str, Any]:
     """Return EXIF metadata for *path*.
 
-    Currently unimplemented; will parse EXIF tags in future.
+    Uses Pillow when available and falls back to an empty dict on failure.
     """
-    raise NotImplementedError
+    try:
+        from PIL import Image, ExifTags  # type: ignore
+
+        with Image.open(path) as img:
+            exif = img.getexif()
+            if not exif:
+                return {}
+            result: Dict[str, Any] = {}
+            for tag_id, value in exif.items():
+                tag = ExifTags.TAGS.get(tag_id, str(tag_id))
+                result[tag] = value
+            return result
+    except Exception:
+        return {}

--- a/src/chatx/media/hash.py
+++ b/src/chatx/media/hash.py
@@ -1,9 +1,17 @@
-"""Hashing utilities."""
+"""Hashing utilities for media files."""
+
+from __future__ import annotations
+
+import hashlib
 
 
-def sha256_stream(path: str) -> str:  # pragma: no cover - NotImplemented
+def sha256_stream(path: str, chunk_size: int = 1024 * 1024) -> str:
     """Return the SHA-256 hex digest for *path*.
 
-    Currently unimplemented; will stream-read file in future.
+    Reads the file in chunks to avoid loading the entire file into memory.
     """
-    raise NotImplementedError
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/src/chatx/media/sniff.py
+++ b/src/chatx/media/sniff.py
@@ -1,9 +1,33 @@
 """MIME sniffing utilities."""
 
+from __future__ import annotations
 
-def sniff_mime(path: str) -> str:  # pragma: no cover - NotImplemented
+
+def sniff_mime(path: str) -> str:
     """Return the detected MIME type for *path*.
 
-    Currently unimplemented; will sniff magic bytes in future.
+    The detector inspects file magic numbers for common image formats.
+    Falls back to ``application/octet-stream`` when unknown.
     """
-    raise NotImplementedError
+
+    with open(path, "rb") as f:
+        header = f.read(12)
+
+    if header.startswith(b"\xFF\xD8"):
+        return "image/jpeg"
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if header[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if header[:4] in (b"II*\x00", b"MM\x00*"):
+        return "image/tiff"
+    if len(header) >= 12 and header[4:12] in (
+        b"ftypheic",
+        b"ftypheix",
+        b"ftyphevc",
+        b"ftyphevx",
+        b"ftypmif1",
+        b"ftypmsf1",
+    ):
+        return "image/heic"
+    return "application/octet-stream"

--- a/src/chatx/utils/run_report.py
+++ b/src/chatx/utils/run_report.py
@@ -21,6 +21,7 @@ def write_extract_run_report(
     finished_at: datetime,
     messages_total: int,
     attachments_total: int,
+    images_total: int,
     throughput_msgs_min: float,
     artifacts: Optional[List[str]] = None,
     warnings: Optional[List[str]] = None,
@@ -42,6 +43,7 @@ def write_extract_run_report(
         "counters": {
             "messages_total": messages_total,
             "attachments_total": attachments_total,
+            "images_total": images_total,
             "throughput_msgs_min": max(0.0, float(throughput_msgs_min)),
         },
         "warnings": warnings or [],
@@ -57,6 +59,7 @@ def write_extract_run_report(
         "summary": {
             "messages_total": messages_total,
             "chunks_total": 0,
+            "images_total": images_total,
             "coverage_min": 0,
             "coverage_max": 0,
             "duration_s": component["duration_s"],

--- a/tests/imessage/test_text_decoding.py
+++ b/tests/imessage/test_text_decoding.py
@@ -13,14 +13,18 @@ from chatx.extractors.imessage import IMessageExtractor
 
 
 def test_decode_attributed_body_plist(tmp_path: Path) -> None:
-    extractor = IMessageExtractor(tmp_path / "chat.db")
-    payload = plistlib.dumps({"string": "Hello world"})
+    db_path = tmp_path / "chat.db"
+    db_path.touch()
+    extractor = IMessageExtractor(db_path)
+    payload = plistlib.dumps({"string": "Hello world"}, fmt=plistlib.FMT_BINARY)
     text = extractor._decode_attributed_body(payload)
     assert text == "Hello world"
 
 
 def test_decode_attributed_body_utf8_fallback(tmp_path: Path) -> None:
-    extractor = IMessageExtractor(tmp_path / "chat.db")
+    db_path = tmp_path / "chat.db"
+    db_path.touch()
+    extractor = IMessageExtractor(db_path)
     payload = "Some utf8 text with ✓".encode("utf-8")
     text = extractor._decode_attributed_body(payload)
     assert "Some utf8 text" in (text or "")
@@ -34,7 +38,7 @@ def test_decode_message_summary_info_plist(tmp_path: Path) -> None:
         conn.execute(
             "CREATE TABLE message_summary_info (message_rowid INTEGER, content BLOB)"
         )
-        payload = plistlib.dumps({"text": "Edited content"})
+        payload = plistlib.dumps({"text": "Edited content"}, fmt=plistlib.FMT_BINARY)
         conn.execute(
             "INSERT INTO message_summary_info VALUES (?, ?)",
             (1, payload),

--- a/tests/media/conftest.py
+++ b/tests/media/conftest.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+
+@pytest.fixture()
+def jpeg_file(tmp_path: Path) -> Path:
+    img = Image.new("RGB", (1, 1), color="red")
+    exif = Image.Exif()
+    exif[271] = "ChatX"  # Make tag
+    path = tmp_path / "test.jpg"
+    img.save(path, exif=exif)
+    return path
+
+
+@pytest.fixture()
+def png_file(tmp_path: Path) -> Path:
+    img = Image.new("RGB", (1, 1), color="red")
+    path = tmp_path / "test.png"
+    img.save(path)
+    return path
+
+
+@pytest.fixture()
+def gif_file(tmp_path: Path) -> Path:
+    img = Image.new("RGB", (1, 1), color="red")
+    path = tmp_path / "test.gif"
+    img.save(path, format="GIF")
+    return path
+
+
+@pytest.fixture()
+def tiff_file(tmp_path: Path) -> Path:
+    img = Image.new("RGB", (1, 1), color="red")
+    path = tmp_path / "test.tiff"
+    img.save(path, format="TIFF")
+    return path
+
+
+@pytest.fixture()
+def heic_file(tmp_path: Path) -> Path:
+    # Minimal HEIC header bytes sufficient for sniffing
+    data = b"\x00\x00\x00\x18ftypheic\x00\x00\x00\x00"
+    path = tmp_path / "test.heic"
+    path.write_bytes(data)
+    return path

--- a/tests/media/test_exif.py
+++ b/tests/media/test_exif.py
@@ -1,10 +1,12 @@
-"""Stub tests for media.exif."""
-
-import pytest
+"""Tests for EXIF parsing utilities."""
 
 from chatx.media.exif import read_exif
 
 
-@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="stub")
-def test_read_exif_unimplemented():
-    read_exif("/dev/null")
+def test_read_exif_returns_metadata(jpeg_file):
+    exif = read_exif(str(jpeg_file))
+    assert exif.get("Make") == "ChatX"
+
+
+def test_read_exif_missing_returns_empty(png_file):
+    assert read_exif(str(png_file)) == {}

--- a/tests/media/test_hash.py
+++ b/tests/media/test_hash.py
@@ -1,10 +1,10 @@
-"""Stub tests for media.hash."""
+"""Tests for media hashing utilities."""
 
-import pytest
+import hashlib
 
 from chatx.media.hash import sha256_stream
 
 
-@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="stub")
-def test_sha256_stream_unimplemented():
-    sha256_stream("/dev/null")
+def test_sha256_stream_matches_hash(jpeg_file):
+    expected = hashlib.sha256(jpeg_file.read_bytes()).hexdigest()
+    assert sha256_stream(str(jpeg_file)) == expected

--- a/tests/media/test_sniff.py
+++ b/tests/media/test_sniff.py
@@ -1,10 +1,23 @@
-"""Stub tests for media.sniff."""
-
-import pytest
+"""Tests for MIME sniffing utilities."""
 
 from chatx.media.sniff import sniff_mime
 
 
-@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="stub")
-def test_sniff_unimplemented():
-    sniff_mime("/dev/null")
+def test_sniff_jpeg(jpeg_file):
+    assert sniff_mime(str(jpeg_file)) == "image/jpeg"
+
+
+def test_sniff_png(png_file):
+    assert sniff_mime(str(png_file)) == "image/png"
+
+
+def test_sniff_gif(gif_file):
+    assert sniff_mime(str(gif_file)) == "image/gif"
+
+
+def test_sniff_tiff(tiff_file):
+    assert sniff_mime(str(tiff_file)) == "image/tiff"
+
+
+def test_sniff_heic(heic_file):
+    assert sniff_mime(str(heic_file)) == "image/heic"

--- a/tests/unit/test_run_report_metrics.py
+++ b/tests/unit/test_run_report_metrics.py
@@ -21,6 +21,7 @@ def test_run_report_and_metrics_schema(tmp_path: Path) -> None:
         finished_at=finished,
         messages_total=10,
         attachments_total=3,
+        images_total=2,
         throughput_msgs_min=300.0,
         artifacts=[str(out / "messages.json")],
         warnings=["warn"],
@@ -37,6 +38,7 @@ def test_run_report_and_metrics_schema(tmp_path: Path) -> None:
         counters={
             "messages_total": 10,
             "attachments_total": 3,
+            "images_total": 2,
             "throughput_msgs_min": 300.0,
         },
         warnings=["warn"],
@@ -52,4 +54,5 @@ def test_run_report_and_metrics_schema(tmp_path: Path) -> None:
     assert obj["counters"]["messages_total"] == 10
     assert obj["counters"]["attachments_total"] == 3
     assert obj["counters"]["throughput_msgs_min"] == 300.0
+    assert obj["counters"]["images_total"] == 2
 

--- a/tests/utils/test_run_report.py
+++ b/tests/utils/test_run_report.py
@@ -18,6 +18,7 @@ class TestRunReport:
             finished_at=finished_at,
             messages_total=10,
             attachments_total=2,
+            images_total=1,
             throughput_msgs_min=300.0,
             artifacts=[str(out / "messages_contact.json")],
             warnings=["example warning"],
@@ -25,6 +26,8 @@ class TestRunReport:
 
         assert report_path.exists()
         assert validate_run_report(report_path) is True
+        data = report_path.read_text(encoding="utf-8")
+        assert '"images_total": 1' in data
 
     def test_validate_run_report_failure(self, tmp_path):
         # Create an invalid report missing required fields


### PR DESCRIPTION
## Summary
- implement image MIME sniffing, hashing, and EXIF helpers
- track image totals in run reports and validate schema in CI
- add tests and fixtures covering JPEG/PNG/GIF/TIFF/HEIC

## Testing
- `ruff check src/chatx/media src/chatx/utils/run_report.py src/chatx/cli/main.py src/chatx/extractors/imessage.py tests/media tests/utils/test_run_report.py tests/unit/test_run_report_metrics.py tests/imessage/test_text_decoding.py`
- `mypy src/chatx/media src/chatx/utils/run_report.py src/chatx/extractors/imessage.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6f5acda28832690ea1259ccc5ebfd