### PR TITLE
test(imessage): cover encrypted backup access

### DIFF
--- a/tests/imessage/test_backup_mode.py
+++ b/tests/imessage/test_backup_mode.py
@@ -107,3 +107,16 @@ def test_backup_encrypted_requires_password(tmp_path: Path) -> None:
     with pytest.raises(PermissionError):
         ensure_backup_accessible(backup_dir, backup_password=None)
 
+
+def test_backup_encrypted_with_password(tmp_path: Path) -> None:
+    """Providing a password for an encrypted backup should pass preflight."""
+    backup_dir = tmp_path / "Backup" / "ENCRYPTED_OK"
+    backup_dir.mkdir(parents=True)
+
+    _init_manifest_db(backup_dir / "Manifest.db")
+    with (backup_dir / "Status.plist").open("wb") as f:
+        plistlib.dump({"IsEncrypted": True}, f)
+
+    # Should not raise when password is supplied
+    ensure_backup_accessible(backup_dir, backup_password="secret")
+


### PR DESCRIPTION
## Summary
- add test ensuring encrypted iPhone backups pass preflight when password provided

## Testing
- `ruff check tests/imessage/test_backup_mode.py`
- `mypy tests/imessage/test_backup_mode.py` (fails: Missing library stubs for chatx.imessage)
- `pytest tests -k 'not thumbnail_generation and not instagram_zip_golden_and_schema' -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7035a45ac8326ab052c524fc6309b