### PR TITLE
docs(cli): document --error-format and error codes; feat(cli): RFC-78…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -148,3 +148,7 @@ chatx enrich messages --backend hybrid --allow-cloud --contact "friend@example.c
 ---
 
 *Last updated: 2025-09-02*
+# Emit machine‑readable CLI errors
+# Add --error-format json to emit RFC-7807 Problem JSON on stderr and set non-zero exit codes
+chatx imessage pull --contact "+1555" --out ./out --error-format json
+chatx instagram pull --zip ./instagram.zip --user "Your Name" --out ./out --error-format json

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -290,3 +290,25 @@ Change Log (since 2025-08-15)
 
 - **SLA**
   - 25k upserts/min on a developer laptop (best-effort).
+### CLI Error Model (RFC‑7807)
+- Flag: `--error-format json|text` (default: text). When `json`, fatal CLI errors are emitted as Problem JSON on stderr and exit non‑zero.
+- Common error codes:
+  - `INVALID_INPUT` — invalid arguments or failed parse (e.g., bad ZIP)
+  - `MISSING_DB` — Messages `chat.db` not found (iMessage paths)
+  - `MISSING_BACKUP_DIR` — backup directory not found
+  - `ENCRYPTED_BACKUP_PASSWORD_REQUIRED` — encrypted backup requires password
+  - `MISSING_ZIP` — Instagram data ZIP not found
+  - `UNSAFE_ZIP_ENTRY` — ZIP contains an unsafe member path (blocked)
+  - `NO_VALID_ROWS` — all rows failed schema validation (see `out/quarantine/messages_bad.jsonl`)
+
+Example (stderr):
+```json
+{
+  "type": "https://chatx.local/problems/NO_VALID_ROWS",
+  "title": "No valid rows",
+  "status": 1,
+  "detail": "All rows failed schema validation; see quarantine/messages_bad.jsonl",
+  "instance": "./out/messages_friend.json",
+  "code": "NO_VALID_ROWS"
+}
+```

--- a/src/chatx/cli/main.py
+++ b/src/chatx/cli/main.py
@@ -1046,7 +1046,6 @@ def instagram_pull(
         raise typer.Exit(1)
 
     # Write output with schema validation
-    from chatx.utils.json_output import write_messages_with_validation
     output_file = out / f"messages_instagram_{zip.stem}.json"
     valid_count, invalid_count = write_messages_with_validation(messages, output_file)
     console.print(f"[bold green]Messages written to:[/bold green] {output_file}")

--- a/src/chatx/cli/main.py
+++ b/src/chatx/cli/main.py
@@ -1008,7 +1008,21 @@ def instagram_pull(
             console.print(f"[bold red]Error:[/bold red] ZIP file not found: {zip}")
         raise typer.Exit(1)
 
-    out.mkdir(parents=True, exist_ok=True)
+    try:
+        out.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        if error_format == "json":
+            from chatx.cli_errors import emit_problem
+            emit_problem(
+                code="DIR_CREATION_FAILED",
+                title="Failed to create output directory",
+                status=1,
+                detail=str(e),
+                instance=str(out),
+            )
+        else:
+            console.print(f"[bold red]Failed to create output directory:[/bold red] {e}")
+        raise typer.Exit(1)
 
     try:
         messages = extract_messages_from_zip(

--- a/src/chatx/cli/main.py
+++ b/src/chatx/cli/main.py
@@ -976,6 +976,7 @@ def instagram_pull(
     out: Path = typer.Option(Path("./out"), "--out", help="Output directory", show_default=True, metavar="<DIR>"),
     user: str = typer.Option(..., "--user", help="Your Instagram display name (filters threads; also marks is_me)", metavar="<NAME>"),
     author_only: list[str] = typer.Option([], "--author-only", help="Include only messages authored by these usernames (repeatable)", metavar="<NAME>", rich_help_panel="Filters"),
+    error_format: str = typer.Option("text", "--error-format", help="Error output format (text|json)"),
 ) -> None:
     """Extract Instagram DMs from the official data ZIP export.
 
@@ -994,7 +995,73 @@ def instagram_pull(
     console.print(f"[blue]Output:[/blue] {out}")
 
     if not zip.exists():
-        console.print(f"[bold red]Error:[/bold red] ZIP file not found: {zip}")
+        if error_format == "json":
+            from chatx.cli_errors import emit_problem
+            emit_problem(
+                code="MISSING_ZIP",
+                title="ZIP file not found",
+                status=1,
+                detail=f"ZIP not found: {zip}",
+                instance=str(zip),
+            )
+        else:
+            console.print(f"[bold red]Error:[/bold red] ZIP file not found: {zip}")
+        raise typer.Exit(1)
+
+    out.mkdir(parents=True, exist_ok=True)
+
+    try:
+        messages = extract_messages_from_zip(
+            zip_path=zip,
+            include_threads_with=[user],
+            authors_only=author_only,
+            me_username=user,
+        )
+    except ValueError as e:
+        # Likely unsafe ZIP entry (Zip Slip) or similar validation failure
+        if error_format == "json":
+            from chatx.cli_errors import emit_problem
+            emit_problem(
+                code="UNSAFE_ZIP_ENTRY",
+                title="Unsafe ZIP entry detected",
+                status=1,
+                detail=str(e),
+                instance=str(zip),
+            )
+        else:
+            console.print(f"[bold red]Unsafe ZIP entry detected[/bold red]: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        if error_format == "json":
+            from chatx.cli_errors import emit_problem
+            emit_problem(
+                code="INVALID_INPUT",
+                title="Failed to parse Instagram ZIP",
+                status=1,
+                detail=str(e),
+                instance=str(zip),
+            )
+        else:
+            console.print(f"[bold red]Failed to parse ZIP:[/bold red] {e}")
+        raise typer.Exit(1)
+
+    # Write output with schema validation
+    from chatx.utils.json_output import write_messages_with_validation
+    output_file = out / f"messages_instagram_{zip.stem}.json"
+    valid_count, invalid_count = write_messages_with_validation(messages, output_file)
+    console.print(f"[bold green]Messages written to:[/bold green] {output_file}")
+    if valid_count == 0:
+        if error_format == "json":
+            from chatx.cli_errors import emit_problem
+            emit_problem(
+                code="NO_VALID_ROWS",
+                title="No valid rows",
+                status=1,
+                detail="All rows failed schema validation; see quarantine/messages_bad.jsonl",
+                instance=str(output_file),
+            )
+        else:
+            console.print("[bold red]No valid rows written (see quarantine/messages_bad.jsonl)[/bold red]")
         raise typer.Exit(1)
 
 

--- a/src/chatx/enrichment/ollama_client.py
+++ b/src/chatx/enrichment/ollama_client.py
@@ -239,7 +239,7 @@ class ProductionOllamaClient:
             for ctx_msg in request.context[-2:]:  # Last 2 messages for context
                 sender = "ME" if ctx_msg.get("is_me") else request.contact
                 context_msgs.append(f"{sender}: {ctx_msg.get('text', '')}")
-            context_str = f"Context:\n" + "\n".join(context_msgs) + "\n\n"
+            context_str = "Context:\n" + "\n".join(context_msgs) + "\n\n"
         
         prompt = f"""{context_str}Analyze this message and provide detailed enrichment following the exact JSON schema:
 

--- a/src/chatx/indexing/pipeline.py
+++ b/src/chatx/indexing/pipeline.py
@@ -183,7 +183,8 @@ class IndexingPipeline:
             if overwrite_collection:
                 logger.info(f"Overwriting existing collection for contact: {contact}")
             
-            collection = self.vector_store.create_collection(contact, overwrite=overwrite_collection)
+            # Create or overwrite target collection
+            self.vector_store.create_collection(contact, overwrite=overwrite_collection)
             self.metrics.collections_created = 1
             
             # Index chunks


### PR DESCRIPTION
…07 for instagram pull errors

- Add CLI error model section with codes and example (interfaces.md); quick examples in README.
- Instagram CLI: --error-format support; structured errors for missing ZIP, unsafe ZIP, parse failures; exit semantics on NO_VALID_ROWS.

## Summary
- What changed and why.

## Checklist (Definition of Done)
- [ ] Tests added/updated and passing (`pytest`)
- [ ] Lint passes (`ruff`)
- [ ] Types pass (`mypy`)
- [ ] Docs updated (`docs/`, ADR if needed)
- [ ] Conventional Commit applied
