### PR TITLE
docs(mkdocs): remove README from nav to resolve conflict with index.m…

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,6 @@ nav:
   - Agent Workflows: agent-workflows.md
   - Repo Prompt XML Apply: repo-prompt-xml.md
   - Additional Docs:
-      - README: README.md
       - LLM Context: CR-XactXtract/llm-context.md
   - How-To:
       - iPhone Backup (iMessage): how-to/iphone-backup.md


### PR DESCRIPTION
…d under --strict

## Summary
- What changed and why.

## Checklist (Definition of Done)
- [ ] Tests added/updated and passing (`pytest`) achore(docs): resolve mkdocs --strict nav conflict; remove README from nav

Body

- Summary:
    - mkdocs --strict aborted due to two warnings:
    - README.md conflicts with index.md as homepage; mkdocs excluded README.md.
    - Nav still referenced README.md, producing a strict warning.
- 
This change removes README from nav; index.md remains the homepage.
- 
Changes:
    - mkdocs.yml
    - Removed “Additional Docs → README: README.md”.

- Rationale:
    - mkdocs warns on conflicting home pages and on nav entries pointing to missing/
excluded files under --strict. Dropping README from nav resolves both warnings.
    - mkdocs warns on conflicting home pages and on nav entries pointing to missing/
excluded files under --strict. Dropping README from nav resolves both warnings.
- 
Expected:
    - mkdocs build --strict passes.
    - “Pages not in nav” warnings are informational and do not stop the build.
- 
Risk:
    - None. Navigation only.
- 
Validation:
    - Local mkdocs config now builds cleanly with index.md as Home.
- [ ] Lint passes (`ruff`)
- [ ] Types pass (`mypy`)
- [ ] Docs updated (`docs/`, ADR if needed)
- [ ] Conventional Commit applied
